### PR TITLE
feat(update-version): update versions on files

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,30 @@ is ready for the next release, then a new `release` branch is created and a new 
 The `release` branch can be deleted, or it can live for as long as you need to give support to that release. If you delete
 the branch you can restore it from the release tag created.
 
+
+### Updating Version Files
+
+When creating a new tag in the repository you can update version files with the new version being released. Only `yaml` files are supported.
+
+To update a version file when creating a new tag you can specify it in the input parameters:
+
+```yaml
+- name: Generate a release tag for Component1
+  uses: intelygenz/monorepo-tagger-action@v1.0
+  with:
+    mode: 'component'
+    type: 'final'
+    component-prefix: "comp1-"
+    update-versions-in: '[{"file": "metaapp/values.yaml", "property": "helloWorld.tag"}]'
+    commit-message: 'My custom commit message'
+    commit-author: 'Me'
+    commit-author-email: 'me@company.com'
+```
+
+### Action inputs
+
+Action inputs are documented in [action.yml file](action.yml)
+
 ## Action Modes
 
 ### Component Release

--- a/action.yml
+++ b/action.yml
@@ -29,9 +29,25 @@ inputs:
     description: 'A pre release name, e.g. "alpha" or "rc"'
     required: false
   tag-branch:
-    description: '"Branch to create a version tag, e.g. "main"'
+    description: 'Branch to create a version tag, e.g. "main"'
     required: false
     default: 'main'
+  update-versions-in:
+    description: 'String representation of an array of objects with file/property keys. If provided the action will update those files/properties with the version that is being released.'
+    required: false
+    default: false
+  commit-message:
+    description: 'The message in the commit for version updates.'
+    required: false
+    default: 'Update version file [skip-ci]'
+  commit-author:
+    description: 'The author for the commit in the version updates.'
+    required: false
+    default: 'Tagger Action'
+  commit-author-email:
+    description: 'The author email for the commit in the version updates.'
+    required: false
+    default: 'tagger-action@automated.com'
   dry-run:
     description: 'Enable dry run mode, e.g. "true" or "false"'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ inputs:
   commit-author-email:
     description: 'The author email for the commit in the version updates.'
     required: false
-    default: 'tagger-action@automated.com'
+    default: 'no-reply-tagger-action@igz.es'
   dry-run:
     description: 'Enable dry run mode, e.g. "true" or "false"'
     required: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,9 @@
       "license": "ISC",
       "dependencies": {
         "@actions/core": "1.6.0",
-        "@actions/github": "4.0.0"
+        "@actions/exec": "^1.1.0",
+        "@actions/github": "4.0.0",
+        "yaml": "2.0.0-8"
       },
       "devDependencies": {
         "@vercel/ncc": "0.25.0",
@@ -32,6 +34,14 @@
         "@actions/http-client": "^1.0.11"
       }
     },
+    "node_modules/@actions/exec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.0.tgz",
+      "integrity": "sha512-LImpN9AY0J1R1mEYJjVJfSZWU4zYOlEcwSTgPve1rFQqK5AwrEs6uWW5Rv70gbDIQIAUwI86z6B+9mPK4w9Sbg==",
+      "dependencies": {
+        "@actions/io": "^1.0.1"
+      }
+    },
     "node_modules/@actions/github": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@actions/github/-/github-4.0.0.tgz",
@@ -50,6 +60,11 @@
       "dependencies": {
         "tunnel": "0.0.6"
       }
+    },
+    "node_modules/@actions/io": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.1.tgz",
+      "integrity": "sha512-Qi4JoKXjmE0O67wAOH6y0n26QXhMKMFo7GD/4IXNVcrtLjUlGjGuVys6pQgwF3ArfGTQu0XpqaNr0YhED2RaRA=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.14.5",
@@ -657,6 +672,15 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
       "version": "13.11.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.11.0.tgz",
@@ -670,6 +694,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/type-fest": {
@@ -718,6 +755,28 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@istanbuljs/schema": {
@@ -1349,6 +1408,44 @@
         }
       }
     },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/globby": {
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
+      "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+      "dev": true,
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.1.1",
+        "ignore": "^5.1.4",
+        "merge2": "^1.3.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/ignore": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
+      "integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -1548,24 +1645,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/array-union": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/astral-regex": {
@@ -1969,6 +2048,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/cross-spawn": {
@@ -2499,6 +2587,15 @@
         "@babel/highlight": "^7.10.4"
       }
     },
+    "node_modules/eslint/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "node_modules/eslint/node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -2524,6 +2621,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/eslint/node_modules/levn": {
@@ -2999,35 +3109,6 @@
       "dev": true,
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/globby": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
-      "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
-      "dev": true,
-      "dependencies": {
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.1.1",
-        "ignore": "^5.1.4",
-        "merge2": "^1.3.0",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/globby/node_modules/ignore": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/graceful-fs": {
@@ -4060,19 +4141,6 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
-    },
-    "node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dev": true,
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
     },
     "node_modules/jsdom": {
       "version": "16.7.0",
@@ -5736,12 +5804,11 @@
       "dev": true
     },
     "node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-      "dev": true,
+      "version": "2.0.0-8",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-8.tgz",
+      "integrity": "sha512-QaYgJZMfWD6fKN/EYMk6w1oLWPCr1xj9QaPSZW5qkDb3y8nGCXhy2Ono+AF4F+CSL/vGcqswcAT0BaS//pgD2A==",
       "engines": {
-        "node": ">= 6"
+        "node": ">= 12"
       }
     },
     "node_modules/yargs": {
@@ -5781,6 +5848,14 @@
         "@actions/http-client": "^1.0.11"
       }
     },
+    "@actions/exec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.0.tgz",
+      "integrity": "sha512-LImpN9AY0J1R1mEYJjVJfSZWU4zYOlEcwSTgPve1rFQqK5AwrEs6uWW5Rv70gbDIQIAUwI86z6B+9mPK4w9Sbg==",
+      "requires": {
+        "@actions/io": "^1.0.1"
+      }
+    },
     "@actions/github": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@actions/github/-/github-4.0.0.tgz",
@@ -5799,6 +5874,11 @@
       "requires": {
         "tunnel": "0.0.6"
       }
+    },
+    "@actions/io": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.1.tgz",
+      "integrity": "sha512-Qi4JoKXjmE0O67wAOH6y0n26QXhMKMFo7GD/4IXNVcrtLjUlGjGuVys6pQgwF3ArfGTQu0XpqaNr0YhED2RaRA=="
     },
     "@babel/code-frame": {
       "version": "7.14.5",
@@ -6261,6 +6341,15 @@
         "strip-json-comments": "^3.1.1"
       },
       "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "dev": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
         "globals": {
           "version": "13.11.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-13.11.0.tgz",
@@ -6268,6 +6357,16 @@
           "dev": true,
           "requires": {
             "type-fest": "^0.20.2"
+          }
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
           }
         },
         "type-fest": {
@@ -6306,6 +6405,27 @@
         "get-package-type": "^0.1.0",
         "js-yaml": "^3.13.1",
         "resolve-from": "^5.0.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "dev": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        }
       }
     },
     "@istanbuljs/schema": {
@@ -6824,6 +6944,32 @@
         "tsutils": "^3.21.0"
       },
       "dependencies": {
+        "array-union": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+          "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+          "dev": true
+        },
+        "globby": {
+          "version": "11.0.4",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
+          "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+          "dev": true,
+          "requires": {
+            "array-union": "^2.1.0",
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.1.1",
+            "ignore": "^5.1.4",
+            "merge2": "^1.3.0",
+            "slash": "^3.0.0"
+          }
+        },
+        "ignore": {
+          "version": "5.1.9",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
+          "integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
+          "dev": true
+        },
         "semver": {
           "version": "7.3.5",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -6964,21 +7110,6 @@
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
       }
-    },
-    "argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "requires": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "array-union": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-      "dev": true
     },
     "astral-regex": {
       "version": "2.0.0",
@@ -7296,6 +7427,14 @@
         "parse-json": "^5.0.0",
         "path-type": "^4.0.0",
         "yaml": "^1.10.0"
+      },
+      "dependencies": {
+        "yaml": {
+          "version": "1.10.2",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+          "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+          "dev": true
+        }
       }
     },
     "cross-spawn": {
@@ -7552,6 +7691,15 @@
             "@babel/highlight": "^7.10.4"
           }
         },
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "dev": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
         "escape-string-regexp": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -7565,6 +7713,16 @@
           "dev": true,
           "requires": {
             "type-fest": "^0.20.2"
+          }
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
           }
         },
         "levn": {
@@ -8056,28 +8214,6 @@
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
-    },
-    "globby": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
-      "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
-      "dev": true,
-      "requires": {
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.1.1",
-        "ignore": "^5.1.4",
-        "merge2": "^1.3.0",
-        "slash": "^3.0.0"
-      },
-      "dependencies": {
-        "ignore": {
-          "version": "5.1.8",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-          "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
-          "dev": true
-        }
-      }
     },
     "graceful-fs": {
       "version": "4.2.8",
@@ -8868,16 +9004,6 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
-    },
-    "js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dev": true,
-      "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      }
     },
     "jsdom": {
       "version": "16.7.0",
@@ -10138,10 +10264,9 @@
       "dev": true
     },
     "yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-      "dev": true
+      "version": "2.0.0-8",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-8.tgz",
+      "integrity": "sha512-QaYgJZMfWD6fKN/EYMk6w1oLWPCr1xj9QaPSZW5qkDb3y8nGCXhy2Ono+AF4F+CSL/vGcqswcAT0BaS//pgD2A=="
     },
     "yargs": {
       "version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "main": "index.js",
   "dependencies": {
     "@actions/core": "1.6.0",
-    "@actions/github": "4.0.0"
+    "@actions/exec": "^1.1.0",
+    "@actions/github": "4.0.0",
+    "yaml": "2.0.0-8"
   },
   "devDependencies": {
     "@vercel/ncc": "0.25.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "dependencies": {
     "@actions/core": "1.6.0",
-    "@actions/exec": "^1.1.0",
+    "@actions/exec": "1.1.0",
     "@actions/github": "4.0.0",
     "yaml": "2.0.0-8"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,10 @@ const mode = core.getInput('mode');
 const tagBranch = core.getInput('tag-branch');
 const currentComponentTag = core.getInput('current-tag');
 const currentMajor = core.getInput('current-major');
+const updateVersionsIn = core.getInput('update-versions-in');
+const commitMessage = core.getInput('commit-message');
+const commitAuthor = core.getInput('commit-author');
+const commitAuthorEmail = core.getInput('commit-author-email');
 
 // Initialize Octokit
 const octokit = github.getOctokit(process.env.GITHUB_TOKEN);
@@ -29,6 +33,10 @@ try {
     currentComponentTag,
     currentMajor,
     preReleaseName,
+    updateVersionsIn,
+    commitMessage,
+    commitAuthor,
+    commitAuthorEmail,
   });
 } catch (e) {
   core.setFailed(`RUN ERROR: \n\t${e}`);

--- a/src/run.test.js
+++ b/src/run.test.js
@@ -8,6 +8,15 @@ const { run } = require('./run');
 describe('mode component', () => {
   let octokitMock, owner, repo;
 
+  const params = {
+    componentPrefix: 'hello-',
+    mode: 'component',
+    type: 'final',
+    tagBranch: 'main',
+    dryRun: false,
+    updateVersionsIn: false,
+  };
+
   beforeEach(() => {
     [owner, repo] = 'test-org/test-repo'.split('/');
 
@@ -47,14 +56,6 @@ describe('mode component', () => {
         const [owner, repo] = 'intelygenz/monorepo-ci-cd-poc'.split('/');
         */
 
-    const params = {
-      componentPrefix: 'hello-',
-      mode: 'component',
-      type: 'final',
-      tagBranch: 'main',
-      dryRun: false,
-    };
-
     await run(octokitMock, owner, repo, params);
 
     expect(core.setFailed).toHaveBeenCalledTimes(0);
@@ -67,13 +68,8 @@ describe('mode component', () => {
     //const octokitMock = github.getOctokit(process.env.GITHUB_TOKEN);
     //const [owner, repo] = 'intelygenz/monorepo-ci-cd-poc'.split('/');
 
-    const params = {
-      componentPrefix: 'hello-',
-      mode: 'component',
-      type: 'fix',
-      dryRun: false,
-      currentComponentTag: 'hello-v0.98.0',
-    };
+    params.currentComponentTag = 'hello-v0.98.0';
+    params.type = 'fix';
 
     github.context.ref = 'refs/heads/release/v0.22';
 
@@ -92,6 +88,17 @@ describe('mode component', () => {
 
 describe('mode product', () => {
   let octokitMock, owner, repo;
+
+  const params = {
+    mode: 'product',
+    type: 'pre-release',
+    dryRun: false,
+    releaseBranchPrefix: 'release/v',
+    currentMajor: '0',
+    tagBranch: 'main',
+    preReleaseName: 'rc',
+    updateVersionsIn: false,
+  };
 
   beforeEach(() => {
     [owner, repo] = 'test-org/test-repo'.split('/');
@@ -138,17 +145,6 @@ describe('mode product', () => {
         const [owner, repo] = 'intelygenz/monorepo-ci-cd-poc'.split('/');
     
     */
-
-    const params = {
-      mode: 'product',
-      type: 'pre-release',
-      dryRun: false,
-      releaseBranchPrefix: 'release/v',
-      currentMajor: '0',
-      tagBranch: 'main',
-      preReleaseName: 'rc',
-    };
-
     await run(octokitMock, owner, repo, params);
 
     expect(core.setFailed).toHaveBeenCalledTimes(0);
@@ -164,16 +160,6 @@ describe('mode product', () => {
     
     */
 
-    const params = {
-      mode: 'product',
-      type: 'pre-release',
-      dryRun: false,
-      releaseBranchPrefix: 'release/v',
-      currentMajor: '0',
-      tagBranch: 'main',
-      preReleaseName: 'rc',
-    };
-
     await run(octokitMock, owner, repo, params);
 
     expect(core.setFailed).toHaveBeenCalledTimes(0);
@@ -188,17 +174,7 @@ describe('mode product', () => {
         const [owner, repo] = 'intelygenz/monorepo-ci-cd-poc'.split('/');
     */
 
-    const params = {
-      componentPrefix: '',
-      releaseBranchPrefix: 'release/v',
-      mode: 'product',
-      type: 'new-release-branch',
-      dryRun: false,
-      tagBranch: 'main',
-      currentComponentTag: 'component-v0.0.0',
-      currentMajor: 0,
-      preReleaseName: '',
-    };
+    params.type = 'new-release-branch';
 
     await run(octokitMock, owner, repo, params);
 
@@ -208,12 +184,7 @@ describe('mode product', () => {
   });
 
   test('calculate-fix-tag', async () => {
-    const params = {
-      mode: 'product',
-      type: 'fix',
-      releaseBranchPrefix: 'release/v',
-      dryRun: true,
-    };
+    params.type = 'fix';
 
     github.context.ref = 'refs/heads/main';
     github.context.payload = {

--- a/src/version-file-updater.js
+++ b/src/version-file-updater.js
@@ -1,0 +1,84 @@
+const fs = require('fs');
+const path = require('path');
+const core = require('@actions/core');
+const actions = require('@actions/exec');
+const yaml = require('yaml');
+
+module.exports = function () {
+  /**
+   * Updates file contents and commit the changes.
+   *
+   * @param files Array with files and properties to be updated [{file: 'filename.yml', property: 'myProp.path'}]
+   * @param version The new version for the property
+   * @param branch The branch to make the changes
+   * @returns sha The commit SHA that was made with the version update
+   */
+  async function updateVersionInFileAndCommit(files, version, branch, commitMessage, author, authorEmail) {
+    const versionFiles = JSON.parse(files);
+    console.log('parsed files are ', versionFiles);
+
+    let filesUpdated = 0;
+
+    versionFiles.forEach((file) => {
+      console.log('file ', file);
+      // only yml files
+      if (!file.file.endsWith('.yml') && !file.file.endsWith('.yaml')) {
+        core.warning(`Only yml files are valid to update the version.`);
+        return;
+      }
+
+      const filePath = path.join(process.cwd(), file.file);
+      if (!fs.existsSync(filePath)) {
+        core.warning(`YML file ${filePath} does not exists`);
+        return;
+      }
+
+      const fileContents = fs.readFileSync(filePath, 'utf8');
+      const ymlObj = yaml.parseDocument(fileContents);
+
+      // update the object property with the version
+      ymlObj.setIn(file.property.split('.'), version);
+      console.log(`Updated ${file.property} to new value ${version}`);
+
+      // write to actual file
+      writeToFile(ymlObj.toString(), file.file);
+      console.log(`Updated contents ${ymlObj.toString()}`);
+      filesUpdated++;
+    });
+
+    // commit the files
+    if (filesUpdated > 0) {
+      return await commitChanges(branch, commitMessage, author, authorEmail);
+    }
+  }
+
+  /**
+   * Commit all changes in a given branch with a given author and commit message.
+   *
+   * @param branch The branch to commit the changes.
+   * @param commitMessage The commit message.
+   * @param authorName The author name.
+   * @param authorEmail The author email.
+   */
+  async function commitChanges(branch, commitMessage, authorName, authorEmail) {
+    await actions.exec('git', ['checkout', branch]);
+    await actions.exec('git', ['add', '-A']);
+    await actions.exec('git', ['config', '--local', 'user.name', authorName]);
+    await actions.exec('git', ['config', '--local', 'user.email', authorEmail]);
+    await actions.exec('git', ['commit', '--no-verify', '-m', commitMessage]);
+    await actions.exec('git', ['push']);
+  }
+
+  function writeToFile(yamlString, filePath) {
+    fs.writeFile(filePath, yamlString, (err) => {
+      if (err) {
+        console.log(err.message);
+        throw err;
+      }
+    });
+  }
+
+  return {
+    updateVersionInFileAndCommit,
+  };
+};

--- a/src/version-file-updater.test.js
+++ b/src/version-file-updater.test.js
@@ -1,0 +1,131 @@
+const updaterMod = require('./version-file-updater');
+const fs = require('fs');
+const actions = require('@actions/exec');
+
+describe('update file with version', () => {
+  fs.writeFile = jest.fn();
+  actions.exec = jest.fn();
+  const updater = updaterMod();
+
+  let version = 'v3.4';
+  let branch = 'main';
+  let commitMessage = 'test commit message';
+  let author = 'author';
+  let authorEmail = 'author@email.com';
+
+  test('error on no yml file', async () => {
+    // GIVEN a file that is not yml
+    const files = [{ file: 'metaapp/values.js', property: 'app.tag' }];
+
+    // WHEN the updater is executed
+    await updater.updateVersionInFileAndCommit(
+      JSON.stringify(files),
+      version,
+      branch,
+      commitMessage,
+      author,
+      authorEmail
+    );
+
+    // THEN no writes and no commits are made
+    expect(fs.writeFile).toHaveBeenCalledTimes(0);
+    expect(actions.exec).toHaveBeenCalledTimes(0);
+  });
+
+  test('two writes for an array of two files', async () => {
+    // GIVEN an array with two files to update
+    const files = [
+      { file: 'test/file.yaml', property: 'app.tag' },
+      { file: 'test/file.yaml', property: 'appVersion' },
+    ];
+
+    // WHEN the updater is executed
+    await updater.updateVersionInFileAndCommit(
+      JSON.stringify(files),
+      version,
+      branch,
+      commitMessage,
+      author,
+      authorEmail
+    );
+
+    // THEN two file writes occurs
+    expect(fs.writeFile).toHaveBeenCalledTimes(2);
+  });
+
+  test('writes a file with updated version', async () => {
+    // GIVEN a file to be updated
+    const files = [{ file: 'test/file.yaml', property: 'app.tag' }];
+
+    // WHEN the updater is executed
+    await updater.updateVersionInFileAndCommit(
+      JSON.stringify(files),
+      version,
+      branch,
+      commitMessage,
+      author,
+      authorEmail
+    );
+
+    // THEN one file is written
+    expect(fs.writeFile).toHaveBeenCalledTimes(1);
+    // AND the content that was written has the exepected updated version
+    const updatedContent = fs.writeFile.mock.calls[0][1];
+    expect(updatedContent).toContain(version);
+  });
+
+  test('preserve comments', async () => {
+    // GIVEN a file to be updated with comments
+    const files = [{ file: 'test/file.yaml', property: 'app.tag' }];
+
+    // WHEN the updater is executed
+    await updater.updateVersionInFileAndCommit(
+      JSON.stringify(files),
+      version,
+      branch,
+      commitMessage,
+      author,
+      authorEmail
+    );
+
+    // THEN one file is written
+    expect(fs.writeFile).toHaveBeenCalledTimes(1);
+    // AND the content that was written has preserved the comments
+    const updatedContent = fs.writeFile.mock.calls[0][1];
+    expect(updatedContent).toContain('# comments');
+    expect(updatedContent).toContain('# inline comment');
+  });
+
+  test('changes are commited', async () => {
+    // GIVEN a file to be updated
+    const files = [{ file: 'test/file.yaml', property: 'app.tag' }];
+
+    // WHEN the updater is executed
+    await updater.updateVersionInFileAndCommit(
+      JSON.stringify(files),
+      version,
+      branch,
+      commitMessage,
+      author,
+      authorEmail
+    );
+
+    // THEN file was commited
+    expect(actions.exec).toHaveBeenCalledTimes(6);
+
+    // AND the commit is correct
+    const checkoutParams = actions.exec.mock.calls[0][1];
+    const addParams = actions.exec.mock.calls[1][1];
+    const configNameParams = actions.exec.mock.calls[2][1];
+    const configEmailParams = actions.exec.mock.calls[3][1];
+    const commitParams = actions.exec.mock.calls[4][1];
+    const pushParams = actions.exec.mock.calls[5][1];
+
+    expect(checkoutParams[1]).toBe(branch); // checkout branch
+    expect(addParams[1]).toBe('-A'); // add -A
+    expect(configNameParams[3]).toBe(author); // config --local user.name author
+    expect(configEmailParams[3]).toBe(authorEmail); // config --local user.name authorEmail
+    expect(commitParams[3]).toBe(commitMessage); // config --local user.name authorEmail
+    expect(pushParams[0]).toBe('push'); // push
+  });
+});

--- a/test/file.yaml
+++ b/test/file.yaml
@@ -1,0 +1,4 @@
+# comments
+version: v2 # inline comment
+app:
+  tag: v3.3


### PR DESCRIPTION
# Motivation

When creating a tag for new version (`rc`, `fix` or `final`) sometimes we also want to update version files. In this scenario, the tag **must** be created after the version change. 

Given that premise make sense that the action have the capability to change the versions files, commit them and then tag that commit with the new version.

# Technical Details

In order to update the version files we are using [yaml library](https://eemeli.org/yaml/#tostring-options). This restrict the versions files to ymls files (More types of version files can be added in new features)

Four new params was added to the action:

| param | desc |
| --- | --- |
| update-versions-in | String representation of an array with objects specifying files and properties path inside the files to be updated with the new version. eg. `'[{"file": "metaapp/values.yaml", "property": "app.tag"}, {"file": "metaapp/Chart.yaml", "property": "appVersion"}]'` | 
| commit-message | The commit message when commiting the updated version files |
| commit-author | The commit author |
| commit-author-email | The commit author email |
