### PR TITLE
feat(action): strip component prefix from tag

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,10 @@ inputs:
     description: 'String representation of an array of objects with file/property keys. If provided the action will update those files/properties with the version that is being released.'
     required: false
     default: false
+  strip-component-from-tag:
+    description: 'If component prefix should be removed from the tag when returning it or using it in a version file'
+    required: false
+    default: false
   commit-message:
     description: 'The message in the commit for version updates.'
     required: false

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ const tagBranch = core.getInput('tag-branch');
 const currentComponentTag = core.getInput('current-tag');
 const currentMajor = core.getInput('current-major');
 const updateVersionsIn = core.getInput('update-versions-in');
+const stripComponentPrefixFromTag = core.getInput('strip-component-from-tag');
 const commitMessage = core.getInput('commit-message');
 const commitAuthor = core.getInput('commit-author');
 const commitAuthorEmail = core.getInput('commit-author-email');
@@ -34,6 +35,7 @@ try {
     currentMajor,
     preReleaseName,
     updateVersionsIn,
+    stripComponentPrefixFromTag,
     commitMessage,
     commitAuthor,
     commitAuthorEmail,

--- a/src/run.js
+++ b/src/run.js
@@ -25,6 +25,7 @@ async function run(
     currentMajor,
     preReleaseName,
     updateVersionsIn,
+    stripComponentPrefixFromTag,
     commitMessage,
     commitAuthor,
     commitAuthorEmail,
@@ -49,6 +50,7 @@ async function run(
     currentMajor,
     preReleaseName,
     updateVersionsIn,
+    stripComponentPrefixFromTag,
     commitMessage,
     commitAuthor,
     commitAuthorEmail,
@@ -94,12 +96,17 @@ async function run(
     return core.setFailed('Tag creation failed');
   }
 
+  let effectiveTag = tag;
+  if (stripComponentPrefixFromTag) {
+    effectiveTag = tag.replace(componentPrefix, '');
+  }
+
   if (!dryRun) {
     // update version filess before the tag is made
     if (updateVersionsIn != false) {
       await versionFileUpdater.updateVersionInFileAndCommit(
         updateVersionsIn,
-        tag,
+        effectiveTag,
         branchToTag,
         commitMessage,
         commitAuthor,
@@ -112,7 +119,7 @@ async function run(
     console.log(`🚀 New tag '${tag}' created in ${branchToTag}`);
   }
 
-  core.setOutput('tag', tag);
+  core.setOutput('tag', effectiveTag);
 }
 
 module.exports = {


### PR DESCRIPTION
# Motivation

When creating a component tag, that tag is prefixed with a `component-prefix`. When we use this tag (for updating a version file or when we return the created tag from the action) may be useful to use it without the component prefix.

closes #6 