### PR TITLE
fix: get branch from workflow_run on fix

### DIFF
--- a/src/product.js
+++ b/src/product.js
@@ -56,7 +56,7 @@ module.exports = function (tags, branches) {
 
     if (type === TYPE_FIX) {
       let currentBranchName = github.context.ref.replace('refs/heads/', '');
-      if (github.context.payload) {
+      if (github.context.payload && github.context.payload.workflow_run) {
         currentBranchName = github.context.payload.workflow_run.head_branch;
       }
       return computeProductFixTag(releaseBranchPrefix, currentBranchName);

--- a/src/product.test.js
+++ b/src/product.test.js
@@ -19,7 +19,7 @@ describe('product FIX', () => {
   test('creates the tag in the release branch when github.context.ref is present', async () => {
     const products = productMod(tags, branches);
 
-    // GIVEN an execution for a fix product with current context 'refs/heads/release-v1.0.0'
+    // GIVEN an execution for a fix product
     type = TYPE_FIX;
 
     // AND the execution branch in the ref is set
@@ -40,10 +40,10 @@ describe('product FIX', () => {
   test('creates the tag in the release branch when github.context.payload from workflow is present', async () => {
     const products = productMod(tags, branches);
 
-    // GIVEN an execution for a fix product with current context 'refs/heads/release-v1.0.0'
+    // GIVEN an execution for a fix product
     type = TYPE_FIX;
 
-    // AND the execution branch in the payload is set
+    // AND the execution branch in the workflow_run payload is set
     github.context.ref = '';
     github.context.payload = {
       workflow_run: {

--- a/src/product.test.js
+++ b/src/product.test.js
@@ -1,0 +1,64 @@
+const productMod = require('./product');
+const { TYPE_FIX } = require('./types');
+const github = require('@actions/github');
+
+describe('product FIX', () => {
+  const tags = {
+    getLatestTagFromReleaseVersion: jest.fn(),
+  };
+
+  const branches = {
+    calcPreReleaseVersionBasedOnReleaseBranches: jest.fn(),
+  };
+
+  let releaseBranchPrefix = 'release-';
+  let type;
+  let preReleaseName = 'rc';
+  let currentMajor = 0;
+
+  test('creates the tag in the release branch when github.context.ref is present', async () => {
+    const products = productMod(tags, branches);
+
+    // GIVEN an execution for a fix product with current context 'refs/heads/release-v1.0.0'
+    type = TYPE_FIX;
+
+    // AND the execution branch in the ref is set
+    github.context.ref = 'refs/heads/release/v0.1';
+    github.context.payload = '';
+
+    // AND the latest tag returns
+    const expectedTag = 'v1.0.0';
+    tags.getLatestTagFromReleaseVersion.mockReturnValue(expectedTag);
+
+    // WHEN the product action is processed
+    const tag = await products.processProduct({ releaseBranchPrefix, type, preReleaseName, currentMajor });
+
+    // THEN the created tag is expectedTag
+    expect(tag).toBe('v1.0.1');
+  });
+
+  test('creates the tag in the release branch when github.context.payload from workflow is present', async () => {
+    const products = productMod(tags, branches);
+
+    // GIVEN an execution for a fix product with current context 'refs/heads/release-v1.0.0'
+    type = TYPE_FIX;
+
+    // AND the execution branch in the payload is set
+    github.context.ref = '';
+    github.context.payload = {
+      workflow_run: {
+        head_branch: 'release/v0.1',
+      },
+    };
+
+    // AND the latest tag returns
+    const expectedTag = 'v1.0.0';
+    tags.getLatestTagFromReleaseVersion.mockReturnValue(expectedTag);
+
+    // WHEN the product action is processed
+    const tag = await products.processProduct({ releaseBranchPrefix, type, preReleaseName, currentMajor });
+
+    // THEN the created tag is expectedTag
+    expect(tag).toBe('v1.0.1');
+  });
+});

--- a/src/run.js
+++ b/src/run.js
@@ -68,6 +68,10 @@ async function run(
 
   if (type === TYPE_FIX) {
     branchToTag = github.context.ref.replace('refs/heads/', '');
+    if (github.context.payload && github.context.payload.workflow_run) {
+      // if executed from a workflow
+      branchToTag = github.context.payload.workflow_run.head_branch;
+    }
   }
 
   switch (mode) {

--- a/src/run.test.js
+++ b/src/run.test.js
@@ -183,10 +183,29 @@ describe('mode product', () => {
     expect(core.setOutput).toHaveBeenCalledWith('tag', 'release/v0.4');
   });
 
-  test('calculate-fix-tag', async () => {
+  test('calculate-fix-tag with github.context.ref', async () => {
     params.type = 'fix';
 
-    github.context.ref = 'refs/heads/main';
+    github.context.ref = 'refs/heads/release/v0.23';
+    github.context.payload = {};
+
+    await run(octokitMock, owner, repo, params);
+
+    expect(core.setFailed).toHaveBeenCalledTimes(0);
+    expect(core.setOutput).toHaveBeenCalledTimes(1);
+    expect(core.setOutput).toHaveBeenCalledWith('tag', 'v0.23.2');
+
+    expect(octokitMock.repos.getBranch).toHaveBeenCalledWith({
+      branch: 'release/v0.23',
+      owner: 'test-org',
+      repo: 'test-repo',
+    });
+  });
+
+  test('calculate-fix-tag with github.context.payload.workflow_run', async () => {
+    params.type = 'fix';
+
+    github.context.ref = '';
     github.context.payload = {
       workflow_run: {
         head_branch: 'release/v0.23',
@@ -198,5 +217,11 @@ describe('mode product', () => {
     expect(core.setFailed).toHaveBeenCalledTimes(0);
     expect(core.setOutput).toHaveBeenCalledTimes(1);
     expect(core.setOutput).toHaveBeenCalledWith('tag', 'v0.23.2');
+
+    expect(octokitMock.repos.getBranch).toHaveBeenCalledWith({
+      branch: 'release/v0.23',
+      owner: 'test-org',
+      repo: 'test-repo',
+    });
   });
 });


### PR DESCRIPTION
When doing a fix, we need to check if the execution was made on a `wofkflow_run`. In that case, the branch to be tagged must be in `github.context.payload.workflow_run.head_branch` instead of the `github.context.ref`