### PR TITLE
feat(version-in-file): options to use the version or tag in the versions file

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ is ready for the next release, then a new `release` branch is created and a new 
 The `release` branch can be deleted, or it can live for as long as you need to give support to that release. If you delete
 the branch you can restore it from the release tag created.
 
+### Action Outputs: TAG and VERSION
+
+The action has two outputs:
+
+- TAG: the tag is the tag that was created (eg. component-v1.0.1)  
+- VERSION: the version is the number in the tag (eg. 1.0.1)
 
 ### Updating Version Files
 

--- a/action.yml
+++ b/action.yml
@@ -36,8 +36,8 @@ inputs:
     description: 'String representation of an array of objects with file/property keys. If provided the action will update those files/properties with the version that is being released.'
     required: false
     default: 'false'
-  strip-component-from-tag:
-    description: 'If component prefix should be removed from the tag when returning it or using it in a version file'
+  use-tag-in-versions-file:
+    description: 'If true, use the tag when updating the versions file. If false use the version instead.'
     required: false
     default: 'false'
   commit-message:

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ const tagBranch = core.getInput('tag-branch');
 const currentComponentTag = core.getInput('current-tag');
 const currentMajor = core.getInput('current-major');
 const updateVersionsIn = core.getInput('update-versions-in');
-const stripComponentPrefixFromTag = core.getInput('strip-component-from-tag');
+const useTagInVersionsFile = core.getInput('use-tag-in-versions-file');
 const commitMessage = core.getInput('commit-message');
 const commitAuthor = core.getInput('commit-author');
 const commitAuthorEmail = core.getInput('commit-author-email');
@@ -35,7 +35,7 @@ try {
     currentMajor,
     preReleaseName,
     updateVersionsIn,
-    stripComponentPrefixFromTag,
+    useTagInVersionsFile,
     commitMessage,
     commitAuthor,
     commitAuthorEmail,

--- a/src/run.js
+++ b/src/run.js
@@ -25,7 +25,7 @@ async function run(
     currentMajor,
     preReleaseName,
     updateVersionsIn,
-    stripComponentPrefixFromTag,
+    useTagInVersionsFile,
     commitMessage,
     commitAuthor,
     commitAuthorEmail,
@@ -50,7 +50,7 @@ async function run(
     currentMajor,
     preReleaseName,
     updateVersionsIn,
-    stripComponentPrefixFromTag,
+    useTagInVersionsFile,
     commitMessage,
     commitAuthor,
     commitAuthorEmail,
@@ -100,10 +100,10 @@ async function run(
     return core.setFailed('Tag creation failed');
   }
 
-  let effectiveTag = tag;
   let version = tag.replace(componentPrefix + 'v', '');
-  if (stripComponentPrefixFromTag) {
-    effectiveTag = tag.replace(componentPrefix, '');
+  let versionInFile = version;
+  if (useTagInVersionsFile) {
+    versionInFile = tag;
   }
 
   if (!dryRun) {
@@ -113,7 +113,7 @@ async function run(
       console.log(`Update versions in files ${updateVersionsIn}`);
       await versionFileUpdater.updateVersionInFileAndCommit(
         updateVersionsIn,
-        effectiveTag,
+        versionInFile,
         branchToTag,
         commitMessage,
         commitAuthor,
@@ -126,7 +126,7 @@ async function run(
     console.log(`🚀 New tag '${tag}' created in ${branchToTag}`);
   }
 
-  core.setOutput('tag', effectiveTag);
+  core.setOutput('tag', tag);
   core.setOutput('version', version);
 }
 


### PR DESCRIPTION
Remove input param `strip-component-from-tag` and add a new input `use-tag-in-versions-file`.

use-tag-in-versions-file = true -> use the tag (eg. `component-v1.2.1` to update the versions file)
use-tag-in-versions-file = false (default value) -> use the version (eg. `1.2.1` to update the versions file)