### PR TITLE
fix: change versionInFile to point to version

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -18083,7 +18083,7 @@ async function run(
 
   let version = tag.replace(componentPrefix + 'v', '');
   let versionInFile = version;
-  if (useTagInVersionsFile) {
+  if (useTagInVersionsFile != 'false') {
     versionInFile = tag;
   }
 

--- a/src/run.js
+++ b/src/run.js
@@ -102,7 +102,7 @@ async function run(
 
   let version = tag.replace(componentPrefix + 'v', '');
   let versionInFile = version;
-  if (useTagInVersionsFile) {
+  if (useTagInVersionsFile != 'false') {
     versionInFile = tag;
   }
 


### PR DESCRIPTION
The file is not updated correctly. We need to validate 'false' because it's a string in `useTagInVersionsFile` variable.