### PR TITLE
fix(parse-version): parse version regexp

### DIFF
--- a/src/strings.js
+++ b/src/strings.js
@@ -1,5 +1,5 @@
 function parseVersion(tag) {
-  const regex = new RegExp(`^v(\\d+).(\\d+)(?:.(\\d+))?`, 'g');
+  const regex = new RegExp(`(\\d+).(\\d+)(?:.(\\d+))?`, 'g');
   const matches = regex.exec(tag);
 
   if (!matches || matches.length <= 0) {

--- a/src/strings.test.js
+++ b/src/strings.test.js
@@ -13,6 +13,18 @@ describe('strings helpers', function () {
     expect(version).toStrictEqual({ major: 1, minor: 2, patch: null });
   });
 
+  test('parseVersion', () => {
+    const version = strings.parseVersion('1.2-rc.0');
+
+    expect(version).toStrictEqual({ major: 1, minor: 2, patch: null });
+  });
+
+  test('parseVersion', () => {
+    const version = strings.parseVersion('1.2.3');
+
+    expect(version).toStrictEqual({ major: 1, minor: 2, patch: 3 });
+  });
+
   test('parseVersion incorrect version', () => {
     const version = strings.parseVersion('bad-format');
 


### PR DESCRIPTION
Fix the regexp in parse version to ignore the tag starting with `v` or without `v`. We dont care about the start of the tag, we just want to extrat the version numbers.