### PR TITLE
feat: prepare repo before changing version files

### DIFF
--- a/src/version-file-updater.js
+++ b/src/version-file-updater.js
@@ -17,6 +17,8 @@ module.exports = function () {
     const versionFiles = JSON.parse(files);
     console.log('parsed files are ', versionFiles);
 
+    await prepareGit(branch);
+
     let filesUpdated = 0;
 
     versionFiles.forEach((file) => {
@@ -48,20 +50,28 @@ module.exports = function () {
 
     // commit the files
     if (filesUpdated > 0) {
-      return await commitChanges(branch, commitMessage, author, authorEmail);
+      return await commitChanges(commitMessage, author, authorEmail);
     }
+  }
+
+  /**
+   * Prepare the git repo by checking out the branch and pulling all changes.
+   *
+   * @param branch The branch to commit the changes.
+   */
+  async function prepareGit(branch) {
+    await actions.exec('git', ['checkout', branch]);
+    await actions.exec('git', ['pull']);
   }
 
   /**
    * Commit all changes in a given branch with a given author and commit message.
    *
-   * @param branch The branch to commit the changes.
    * @param commitMessage The commit message.
    * @param authorName The author name.
    * @param authorEmail The author email.
    */
-  async function commitChanges(branch, commitMessage, authorName, authorEmail) {
-    await actions.exec('git', ['checkout', branch]);
+  async function commitChanges(commitMessage, authorName, authorEmail) {
     await actions.exec('git', ['add', '-A']);
     await actions.exec('git', ['config', '--local', 'user.name', authorName]);
     await actions.exec('git', ['config', '--local', 'user.email', authorEmail]);

--- a/src/version-file-updater.js
+++ b/src/version-file-updater.js
@@ -17,6 +17,9 @@ module.exports = function () {
     const versionFiles = JSON.parse(files);
     console.log('parsed files are ', versionFiles);
 
+    // Checkout the branch and update the repo contents.
+    // This is needed to avoid conflicts if another process has updated the repo after the commit that trigger
+    // the workflow using this action.
     await prepareGit(branch);
 
     let filesUpdated = 0;
@@ -65,7 +68,7 @@ module.exports = function () {
   }
 
   /**
-   * Commit all changes in a given branch with a given author and commit message.
+   * Commit all changes with a given author and commit message.
    *
    * @param commitMessage The commit message.
    * @param authorName The author name.

--- a/src/version-file-updater.test.js
+++ b/src/version-file-updater.test.js
@@ -29,7 +29,7 @@ describe('update file with version', () => {
 
     // THEN no writes and no commits are made
     expect(fs.writeFile).toHaveBeenCalledTimes(0);
-    expect(actions.exec).toHaveBeenCalledTimes(0);
+    expect(actions.exec).toHaveBeenCalledTimes(2); // checkout + pull
   });
 
   test('two writes for an array of two files', async () => {
@@ -111,21 +111,23 @@ describe('update file with version', () => {
     );
 
     // THEN file was commited
-    expect(actions.exec).toHaveBeenCalledTimes(6);
+    expect(actions.exec).toHaveBeenCalledTimes(7);
 
     // AND the commit is correct
     const checkoutParams = actions.exec.mock.calls[0][1];
-    const addParams = actions.exec.mock.calls[1][1];
-    const configNameParams = actions.exec.mock.calls[2][1];
-    const configEmailParams = actions.exec.mock.calls[3][1];
-    const commitParams = actions.exec.mock.calls[4][1];
-    const pushParams = actions.exec.mock.calls[5][1];
+    const pullParams = actions.exec.mock.calls[1][1];
+    const addParams = actions.exec.mock.calls[2][1];
+    const configNameParams = actions.exec.mock.calls[3][1];
+    const configEmailParams = actions.exec.mock.calls[4][1];
+    const commitParams = actions.exec.mock.calls[5][1];
+    const pushParams = actions.exec.mock.calls[6][1];
 
     expect(checkoutParams[1]).toBe(branch); // checkout branch
+    expect(pullParams[0]).toBe('pull'); // pull
     expect(addParams[1]).toBe('-A'); // add -A
     expect(configNameParams[3]).toBe(author); // config --local user.name author
     expect(configEmailParams[3]).toBe(authorEmail); // config --local user.name authorEmail
-    expect(commitParams[3]).toBe(commitMessage); // config --local user.name authorEmail
+    expect(commitParams[3]).toBe(commitMessage); // commit --no-verify -m commitMessage
     expect(pushParams[0]).toBe('push'); // push
   });
 });


### PR DESCRIPTION
Checkout the branch and update the repo contents before making any changes to files.

This is needed to avoid conflicts if another process has updated the repo contents after the commit that trigger the workflow using this action.